### PR TITLE
ci: replace docker image to solve eureka server response-cache-update-int…

### DIFF
--- a/.github/workflows/push-check.yml
+++ b/.github/workflows/push-check.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       eureka:
-        image: 'springcloud/eureka'
+        image: 'xdockerh/eureka-server:latest'
         ports:
           - 8761:8761
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,6 @@ version: '3'
 
 services:
   eureka:
-    image: 'springcloud/eureka'
+    image: 'xdockerh/eureka-server:latest'
     ports:
       - 8761:8761


### PR DESCRIPTION
en: Replace docker image to Solve the problem that the service discovery after service registration in unit testing and the instance list is delayed by 30s.
zh: 替换docker镜像去解决单元测试中服务注册后进行服务发现拉取实例列表延迟30s的问题